### PR TITLE
Adding gamepad controller

### DIFF
--- a/android/app/src/main/kotlin/com/example/test/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/test/MainActivity.kt
@@ -1,6 +1,29 @@
 package com.example.test
 
+import android.view.KeyEvent
+import android.view.MotionEvent
+import com.example.test.controller.ExternalController
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
 
 class MainActivity: FlutterActivity() {
+    private val externalController = ExternalController()
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        externalController.initialize(flutterEngine)
+    }
+
+    override fun onGenericMotionEvent(event: MotionEvent): Boolean {
+        return externalController.handleOnGenericMotionEvent(event)
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        val handle = externalController.handleKeyEvent(keyCode, event, "ACTION_DOWN")
+        return if(handle) handle else super.onKeyDown(keyCode, event)
+    }
+    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+        val handle = externalController.handleKeyEvent(keyCode, event, "ACTION_UP")
+        return if(handle) handle else super.onKeyUp(keyCode, event)
+    }
 }

--- a/android/app/src/main/kotlin/com/example/test/controller/ControllerKeysData.kt
+++ b/android/app/src/main/kotlin/com/example/test/controller/ControllerKeysData.kt
@@ -1,0 +1,12 @@
+package com.example.test.controller
+
+enum class ControllerKeysData {
+    AXIS,
+    BUTTON,
+    CREATE,
+    DPAD,
+    AXIS_RTRIGGER,
+    AXIS_LTRIGGER,
+    STICK_LEFT,
+    STICK_RIGHT
+}

--- a/android/app/src/main/kotlin/com/example/test/controller/ControllerUtils.kt
+++ b/android/app/src/main/kotlin/com/example/test/controller/ControllerUtils.kt
@@ -1,0 +1,85 @@
+package com.example.test.controller
+
+import android.view.InputDevice
+import android.view.InputEvent
+import android.view.KeyEvent
+import android.view.MotionEvent
+import kotlin.math.abs
+
+object ControllerUtils {
+    const val UP = 0
+    const val LEFT = 1
+    const val RIGHT = 2
+    const val DOWN = 3
+    const val CENTER = 4
+
+    fun isDpadDevice(inputEvent: InputEvent) : Boolean {
+        return (inputEvent.source and InputDevice.SOURCE_DPAD) != InputDevice.SOURCE_DPAD
+    }
+
+    fun isJoystick(inputEvent: MotionEvent): Boolean{
+        return ((inputEvent.source and InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK) && inputEvent.action == MotionEvent.ACTION_MOVE
+    }
+
+    fun getDpadDirection(inputEvent: InputEvent): Int{
+        if(!isDpadDevice(inputEvent)) return -1
+        return when(inputEvent){
+            is MotionEvent -> {
+                var direction = -1
+                val xAxis = inputEvent.getAxisValue(MotionEvent.AXIS_HAT_X)
+                val yAxis = inputEvent.getAxisValue(MotionEvent.AXIS_HAT_Y)
+                when {
+                    xAxis == -1f -> {
+                        direction = LEFT
+                    }
+                    xAxis == 1f -> {
+                        direction = RIGHT
+                    }
+                    yAxis == -1f -> {
+                        direction = UP
+                    }
+                    yAxis == 1f -> {
+                        direction = DOWN
+                    }
+                }
+                direction
+            }
+            is KeyEvent -> {
+                val direction = when (inputEvent.keyCode) {
+                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                        LEFT
+                    }
+                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                        RIGHT
+                    }
+                    KeyEvent.KEYCODE_DPAD_UP -> {
+                        UP
+                    }
+                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                        DOWN
+                    }
+                    KeyEvent.KEYCODE_DPAD_CENTER -> {
+                        CENTER
+                    }
+                    else -> {
+                        -1
+                    }
+                }
+                direction
+            }
+            else -> -1
+        }
+    }
+
+    fun getCenteredAxis(event: MotionEvent, axis: Int): Float {
+        val range = event.device.getMotionRange(axis, event.source)
+        if(range != null){
+            val flat = range.flat
+            val value = event.getAxisValue(axis)
+            if(abs(value) > flat){
+                return value
+            }
+        }
+        return 0f
+    }
+}

--- a/android/app/src/main/kotlin/com/example/test/controller/EventManager.kt
+++ b/android/app/src/main/kotlin/com/example/test/controller/EventManager.kt
@@ -1,0 +1,27 @@
+package com.example.test.controller
+
+import io.flutter.plugin.common.EventChannel
+
+class EventManager {
+    companion object {
+        private const val EVENT_DPAD = "androidType=%s,~direction=%d"
+    }
+
+    private var eventSink: EventChannel.EventSink? = null
+
+    fun setEventSink(eventSink: EventChannel.EventSink?){
+        this.eventSink = eventSink
+    }
+
+    fun sendDpadEvent(direction: Int){
+        eventSink?.success("androidType=${ControllerKeysData.DPAD},~direction=$direction")
+    }
+
+    fun sendAxisEvent(source: ControllerKeysData, axisName: String, xValue: Float = 0f, yValue: Float = 0f){
+        eventSink?.success("androidType=${ControllerKeysData.AXIS},~sourceInput=$source,~axisType=$axisName,~x=$xValue,~y=$yValue")
+    }
+
+    fun sendButtonEvent(action: String, code: Int){
+        eventSink?.success("androidType=${ControllerKeysData.BUTTON},~keyAction=$action,~keyCode=$code")
+    }
+}

--- a/android/app/src/main/kotlin/com/example/test/controller/ExternalController.kt
+++ b/android/app/src/main/kotlin/com/example/test/controller/ExternalController.kt
@@ -1,0 +1,94 @@
+package com.example.test.controller
+
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.InputDevice
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+
+class ExternalController {
+    companion object {
+        private const val CHANNEL = "com.example.test/gamepad_channel"
+    }
+
+    private val eventManager = EventManager()
+
+    private var isRTriggerZero = true
+    private var isLTriggerZero = true
+    private var isStickLeftZero = true
+    private var isStickRightZero = true
+
+    fun initialize(flutterEngine: FlutterEngine){
+        EventChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setStreamHandler(object : EventChannel.StreamHandler {
+            override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+                eventManager.setEventSink(events)
+            }
+
+            override fun onCancel(arguments: Any?) {
+                eventManager.setEventSink(null)
+            }
+        })
+    }
+
+    fun handleOnGenericMotionEvent(event: MotionEvent) : Boolean {
+        if(ControllerUtils.isDpadDevice(event)){
+            eventManager.sendDpadEvent(ControllerUtils.getDpadDirection(event))
+        }
+        if(ControllerUtils.isJoystick(event)){
+            processJoystickInput(event)
+            return true
+        }
+        return false
+    }
+
+    private fun processJoystickInput(event: MotionEvent){
+        val axisRTrigger = event.getAxisValue(MotionEvent.AXIS_RTRIGGER)
+        val axisLTrigger = event.getAxisValue(MotionEvent.AXIS_LTRIGGER)
+        // RT
+        if(axisRTrigger != 0f){
+            isRTriggerZero = false
+            eventManager.sendAxisEvent(ControllerKeysData.AXIS_RTRIGGER, "AXIS_RTRIGGER", axisRTrigger)
+        } else if(!isRTriggerZero && axisRTrigger == 0f){
+            isRTriggerZero = true
+            eventManager.sendAxisEvent(ControllerKeysData.AXIS_RTRIGGER, "AXIS_RTRIGGER")
+        }
+        // LT
+        if(axisLTrigger != 0f){
+            isLTriggerZero = false
+            eventManager.sendAxisEvent(ControllerKeysData.AXIS_LTRIGGER, "AXIS_LTRIGGER", axisLTrigger)
+        } else if(!isLTriggerZero && axisLTrigger == 0f){
+            isLTriggerZero = true
+            eventManager.sendAxisEvent(ControllerKeysData.AXIS_LTRIGGER, "AXIS_LTRIGGER")
+        }
+        // stick (left)
+        val x = ControllerUtils.getCenteredAxis(event, MotionEvent.AXIS_X)
+        val y = ControllerUtils.getCenteredAxis(event, MotionEvent.AXIS_Y)
+        if((x != 0f) or (y != 0f)){
+            isStickLeftZero = false
+            eventManager.sendAxisEvent(ControllerKeysData.STICK_LEFT, "STICK_LEFT", x, y)
+        } else if(!isStickLeftZero && x == 0f && y == 0f){
+            isStickLeftZero = true
+            eventManager.sendAxisEvent(ControllerKeysData.STICK_LEFT, "STICK_LEFT")
+        }
+        // stick (right)
+        val z = ControllerUtils.getCenteredAxis(event, MotionEvent.AXIS_Z)
+        val rz = ControllerUtils.getCenteredAxis(event, MotionEvent.AXIS_RZ)
+        if((z != 0f) or (rz != 0f)){
+            isStickRightZero = false
+            eventManager.sendAxisEvent(ControllerKeysData.STICK_RIGHT, "STICK_RIGHT", z, rz)
+        } else if(!isStickRightZero && z == 0f && rz == 0f){
+            isStickRightZero = true
+            eventManager.sendAxisEvent(ControllerKeysData.STICK_RIGHT, "STICK_RIGHT")
+        }
+    }
+
+    fun handleKeyEvent(keyCode: Int, event: KeyEvent, action: String): Boolean {
+        eventManager.sendButtonEvent(action, keyCode)
+        val keyCodeBool = (keyCode == KeyEvent.KEYCODE_BACK) or (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) or (keyCode == KeyEvent.KEYCODE_VOLUME_UP)
+        val keyboardTypeBool = event.device.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC
+        if (keyboardTypeBool && keyCodeBool && event.device.isVirtual) {
+            return false
+        }
+        return true
+    }
+}

--- a/lib/models/gamepad/gamepad_axis_type.dart
+++ b/lib/models/gamepad/gamepad_axis_type.dart
@@ -1,0 +1,11 @@
+enum GamepadAxisType { left, right }
+
+enum GamepadTriggerType { left, right }
+
+enum GamepadBumperType { left, right }
+
+enum GamepadDPadType { left, right, up, down }
+
+enum GamepadButtonType { x, y, a, b, select, start, center3, home }
+
+enum GamepadCommandType { axis, trigger, bumper, dpad, button }

--- a/lib/models/gamepad/gamepad_command_type.dart
+++ b/lib/models/gamepad/gamepad_command_type.dart
@@ -1,0 +1,88 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'gamepad_axis_type.dart';
+
+part 'gamepad_command_type.freezed.dart';
+part 'gamepad_command_type.g.dart';
+
+class GamepadCommand {
+  final GamepadCommandType type;
+  final dynamic command;
+  GamepadCommand({required this.type, required this.command});
+
+  dynamic _getCommand(GamepadCommandType type, dynamic command) {
+    switch (type) {
+      case GamepadCommandType.axis:
+        return GamepadAxisCommand.fromJson(command);
+      case GamepadCommandType.trigger:
+        return GamepadTriggerCommand.fromJson(command);
+      case GamepadCommandType.bumper:
+        return GamepadBumperCommand.fromJson(command);
+      case GamepadCommandType.dpad:
+        return GamepadDPadCommand.fromJson(command);
+      case GamepadCommandType.button:
+        return GamepadButtonCommand.fromJson(command);
+      default:
+    }
+  }
+
+  static GamepadCommandType _getValue(String val) {
+    switch (val) {
+      case "axis":
+        return GamepadCommandType.axis;
+      case "trigger":
+        return GamepadCommandType.trigger;
+      case "bumper":
+        return GamepadCommandType.bumper;
+      case "dpad":
+        return GamepadCommandType.dpad;
+      case "button":
+        return GamepadCommandType.button;
+      default:
+        return GamepadCommandType.button;
+    }
+  }
+
+  Map<String, dynamic> fromJson(Map<String, dynamic> json) => <String, dynamic>{
+        'type': _getValue(json['type']),
+        'command': _getCommand(json['type'], json['command']),
+      };
+}
+
+@freezed
+class GamepadAxisCommand with _$GamepadAxisCommand {
+  const factory GamepadAxisCommand(
+      {required GamepadAxisType type,
+      required double x, //RoverStateType
+      required double y}) = _GamepadAxisCommand;
+
+  factory GamepadAxisCommand.fromJson(Map<String, dynamic> json) => _$GamepadAxisCommandFromJson(json);
+}
+
+@freezed
+class GamepadTriggerCommand with _$GamepadTriggerCommand {
+  const factory GamepadTriggerCommand({required GamepadTriggerType type, required double value}) = _GamepadTriggerCommand;
+
+  factory GamepadTriggerCommand.fromJson(Map<String, dynamic> json) => _$GamepadTriggerCommandFromJson(json);
+}
+
+@freezed
+class GamepadBumperCommand with _$GamepadBumperCommand {
+  const factory GamepadBumperCommand({required GamepadBumperType type, required double isPressed}) = _GamepadBumperCommand;
+
+  factory GamepadBumperCommand.fromJson(Map<String, dynamic> json) => _$GamepadBumperCommandFromJson(json);
+}
+
+@freezed
+class GamepadDPadCommand with _$GamepadDPadCommand {
+  const factory GamepadDPadCommand({required GamepadDPadType type, required int isPressed}) = _GamepadDPadCommand;
+
+  factory GamepadDPadCommand.fromJson(Map<String, dynamic> json) => _$GamepadDPadCommandFromJson(json);
+}
+
+@freezed
+class GamepadButtonCommand with _$GamepadButtonCommand {
+  const factory GamepadButtonCommand({required GamepadButtonType type, required bool isPressed}) = _GamepadButtonCommand;
+
+  factory GamepadButtonCommand.fromJson(Map<String, dynamic> json) => _$GamepadButtonCommandFromJson(json);
+}

--- a/lib/models/gamepad/gamepad_command_type.freezed.dart
+++ b/lib/models/gamepad/gamepad_command_type.freezed.dart
@@ -1,0 +1,802 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'gamepad_command_type.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+GamepadAxisCommand _$GamepadAxisCommandFromJson(Map<String, dynamic> json) {
+  return _GamepadAxisCommand.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GamepadAxisCommand {
+  GamepadAxisType get type => throw _privateConstructorUsedError;
+  double get x => throw _privateConstructorUsedError; //RoverStateType
+  double get y => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GamepadAxisCommandCopyWith<GamepadAxisCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GamepadAxisCommandCopyWith<$Res> {
+  factory $GamepadAxisCommandCopyWith(
+          GamepadAxisCommand value, $Res Function(GamepadAxisCommand) then) =
+      _$GamepadAxisCommandCopyWithImpl<$Res>;
+  $Res call({GamepadAxisType type, double x, double y});
+}
+
+/// @nodoc
+class _$GamepadAxisCommandCopyWithImpl<$Res>
+    implements $GamepadAxisCommandCopyWith<$Res> {
+  _$GamepadAxisCommandCopyWithImpl(this._value, this._then);
+
+  final GamepadAxisCommand _value;
+  // ignore: unused_field
+  final $Res Function(GamepadAxisCommand) _then;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? x = freezed,
+    Object? y = freezed,
+  }) {
+    return _then(_value.copyWith(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadAxisType,
+      x: x == freezed
+          ? _value.x
+          : x // ignore: cast_nullable_to_non_nullable
+              as double,
+      y: y == freezed
+          ? _value.y
+          : y // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_GamepadAxisCommandCopyWith<$Res>
+    implements $GamepadAxisCommandCopyWith<$Res> {
+  factory _$$_GamepadAxisCommandCopyWith(_$_GamepadAxisCommand value,
+          $Res Function(_$_GamepadAxisCommand) then) =
+      __$$_GamepadAxisCommandCopyWithImpl<$Res>;
+  @override
+  $Res call({GamepadAxisType type, double x, double y});
+}
+
+/// @nodoc
+class __$$_GamepadAxisCommandCopyWithImpl<$Res>
+    extends _$GamepadAxisCommandCopyWithImpl<$Res>
+    implements _$$_GamepadAxisCommandCopyWith<$Res> {
+  __$$_GamepadAxisCommandCopyWithImpl(
+      _$_GamepadAxisCommand _value, $Res Function(_$_GamepadAxisCommand) _then)
+      : super(_value, (v) => _then(v as _$_GamepadAxisCommand));
+
+  @override
+  _$_GamepadAxisCommand get _value => super._value as _$_GamepadAxisCommand;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? x = freezed,
+    Object? y = freezed,
+  }) {
+    return _then(_$_GamepadAxisCommand(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadAxisType,
+      x: x == freezed
+          ? _value.x
+          : x // ignore: cast_nullable_to_non_nullable
+              as double,
+      y: y == freezed
+          ? _value.y
+          : y // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_GamepadAxisCommand implements _GamepadAxisCommand {
+  const _$_GamepadAxisCommand(
+      {required this.type, required this.x, required this.y});
+
+  factory _$_GamepadAxisCommand.fromJson(Map<String, dynamic> json) =>
+      _$$_GamepadAxisCommandFromJson(json);
+
+  @override
+  final GamepadAxisType type;
+  @override
+  final double x;
+//RoverStateType
+  @override
+  final double y;
+
+  @override
+  String toString() {
+    return 'GamepadAxisCommand(type: $type, x: $x, y: $y)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_GamepadAxisCommand &&
+            const DeepCollectionEquality().equals(other.type, type) &&
+            const DeepCollectionEquality().equals(other.x, x) &&
+            const DeepCollectionEquality().equals(other.y, y));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(type),
+      const DeepCollectionEquality().hash(x),
+      const DeepCollectionEquality().hash(y));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_GamepadAxisCommandCopyWith<_$_GamepadAxisCommand> get copyWith =>
+      __$$_GamepadAxisCommandCopyWithImpl<_$_GamepadAxisCommand>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_GamepadAxisCommandToJson(this);
+  }
+}
+
+abstract class _GamepadAxisCommand implements GamepadAxisCommand {
+  const factory _GamepadAxisCommand(
+      {required final GamepadAxisType type,
+      required final double x,
+      required final double y}) = _$_GamepadAxisCommand;
+
+  factory _GamepadAxisCommand.fromJson(Map<String, dynamic> json) =
+      _$_GamepadAxisCommand.fromJson;
+
+  @override
+  GamepadAxisType get type => throw _privateConstructorUsedError;
+  @override
+  double get x => throw _privateConstructorUsedError;
+  @override //RoverStateType
+  double get y => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_GamepadAxisCommandCopyWith<_$_GamepadAxisCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+GamepadTriggerCommand _$GamepadTriggerCommandFromJson(
+    Map<String, dynamic> json) {
+  return _GamepadTriggerCommand.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GamepadTriggerCommand {
+  GamepadTriggerType get type => throw _privateConstructorUsedError;
+  double get value => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GamepadTriggerCommandCopyWith<GamepadTriggerCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GamepadTriggerCommandCopyWith<$Res> {
+  factory $GamepadTriggerCommandCopyWith(GamepadTriggerCommand value,
+          $Res Function(GamepadTriggerCommand) then) =
+      _$GamepadTriggerCommandCopyWithImpl<$Res>;
+  $Res call({GamepadTriggerType type, double value});
+}
+
+/// @nodoc
+class _$GamepadTriggerCommandCopyWithImpl<$Res>
+    implements $GamepadTriggerCommandCopyWith<$Res> {
+  _$GamepadTriggerCommandCopyWithImpl(this._value, this._then);
+
+  final GamepadTriggerCommand _value;
+  // ignore: unused_field
+  final $Res Function(GamepadTriggerCommand) _then;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? value = freezed,
+  }) {
+    return _then(_value.copyWith(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadTriggerType,
+      value: value == freezed
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_GamepadTriggerCommandCopyWith<$Res>
+    implements $GamepadTriggerCommandCopyWith<$Res> {
+  factory _$$_GamepadTriggerCommandCopyWith(_$_GamepadTriggerCommand value,
+          $Res Function(_$_GamepadTriggerCommand) then) =
+      __$$_GamepadTriggerCommandCopyWithImpl<$Res>;
+  @override
+  $Res call({GamepadTriggerType type, double value});
+}
+
+/// @nodoc
+class __$$_GamepadTriggerCommandCopyWithImpl<$Res>
+    extends _$GamepadTriggerCommandCopyWithImpl<$Res>
+    implements _$$_GamepadTriggerCommandCopyWith<$Res> {
+  __$$_GamepadTriggerCommandCopyWithImpl(_$_GamepadTriggerCommand _value,
+      $Res Function(_$_GamepadTriggerCommand) _then)
+      : super(_value, (v) => _then(v as _$_GamepadTriggerCommand));
+
+  @override
+  _$_GamepadTriggerCommand get _value =>
+      super._value as _$_GamepadTriggerCommand;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? value = freezed,
+  }) {
+    return _then(_$_GamepadTriggerCommand(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadTriggerType,
+      value: value == freezed
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_GamepadTriggerCommand implements _GamepadTriggerCommand {
+  const _$_GamepadTriggerCommand({required this.type, required this.value});
+
+  factory _$_GamepadTriggerCommand.fromJson(Map<String, dynamic> json) =>
+      _$$_GamepadTriggerCommandFromJson(json);
+
+  @override
+  final GamepadTriggerType type;
+  @override
+  final double value;
+
+  @override
+  String toString() {
+    return 'GamepadTriggerCommand(type: $type, value: $value)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_GamepadTriggerCommand &&
+            const DeepCollectionEquality().equals(other.type, type) &&
+            const DeepCollectionEquality().equals(other.value, value));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(type),
+      const DeepCollectionEquality().hash(value));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_GamepadTriggerCommandCopyWith<_$_GamepadTriggerCommand> get copyWith =>
+      __$$_GamepadTriggerCommandCopyWithImpl<_$_GamepadTriggerCommand>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_GamepadTriggerCommandToJson(this);
+  }
+}
+
+abstract class _GamepadTriggerCommand implements GamepadTriggerCommand {
+  const factory _GamepadTriggerCommand(
+      {required final GamepadTriggerType type,
+      required final double value}) = _$_GamepadTriggerCommand;
+
+  factory _GamepadTriggerCommand.fromJson(Map<String, dynamic> json) =
+      _$_GamepadTriggerCommand.fromJson;
+
+  @override
+  GamepadTriggerType get type => throw _privateConstructorUsedError;
+  @override
+  double get value => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_GamepadTriggerCommandCopyWith<_$_GamepadTriggerCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+GamepadBumperCommand _$GamepadBumperCommandFromJson(Map<String, dynamic> json) {
+  return _GamepadBumperCommand.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GamepadBumperCommand {
+  GamepadBumperType get type => throw _privateConstructorUsedError;
+  double get isPressed => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GamepadBumperCommandCopyWith<GamepadBumperCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GamepadBumperCommandCopyWith<$Res> {
+  factory $GamepadBumperCommandCopyWith(GamepadBumperCommand value,
+          $Res Function(GamepadBumperCommand) then) =
+      _$GamepadBumperCommandCopyWithImpl<$Res>;
+  $Res call({GamepadBumperType type, double isPressed});
+}
+
+/// @nodoc
+class _$GamepadBumperCommandCopyWithImpl<$Res>
+    implements $GamepadBumperCommandCopyWith<$Res> {
+  _$GamepadBumperCommandCopyWithImpl(this._value, this._then);
+
+  final GamepadBumperCommand _value;
+  // ignore: unused_field
+  final $Res Function(GamepadBumperCommand) _then;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? isPressed = freezed,
+  }) {
+    return _then(_value.copyWith(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadBumperType,
+      isPressed: isPressed == freezed
+          ? _value.isPressed
+          : isPressed // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_GamepadBumperCommandCopyWith<$Res>
+    implements $GamepadBumperCommandCopyWith<$Res> {
+  factory _$$_GamepadBumperCommandCopyWith(_$_GamepadBumperCommand value,
+          $Res Function(_$_GamepadBumperCommand) then) =
+      __$$_GamepadBumperCommandCopyWithImpl<$Res>;
+  @override
+  $Res call({GamepadBumperType type, double isPressed});
+}
+
+/// @nodoc
+class __$$_GamepadBumperCommandCopyWithImpl<$Res>
+    extends _$GamepadBumperCommandCopyWithImpl<$Res>
+    implements _$$_GamepadBumperCommandCopyWith<$Res> {
+  __$$_GamepadBumperCommandCopyWithImpl(_$_GamepadBumperCommand _value,
+      $Res Function(_$_GamepadBumperCommand) _then)
+      : super(_value, (v) => _then(v as _$_GamepadBumperCommand));
+
+  @override
+  _$_GamepadBumperCommand get _value => super._value as _$_GamepadBumperCommand;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? isPressed = freezed,
+  }) {
+    return _then(_$_GamepadBumperCommand(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadBumperType,
+      isPressed: isPressed == freezed
+          ? _value.isPressed
+          : isPressed // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_GamepadBumperCommand implements _GamepadBumperCommand {
+  const _$_GamepadBumperCommand({required this.type, required this.isPressed});
+
+  factory _$_GamepadBumperCommand.fromJson(Map<String, dynamic> json) =>
+      _$$_GamepadBumperCommandFromJson(json);
+
+  @override
+  final GamepadBumperType type;
+  @override
+  final double isPressed;
+
+  @override
+  String toString() {
+    return 'GamepadBumperCommand(type: $type, isPressed: $isPressed)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_GamepadBumperCommand &&
+            const DeepCollectionEquality().equals(other.type, type) &&
+            const DeepCollectionEquality().equals(other.isPressed, isPressed));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(type),
+      const DeepCollectionEquality().hash(isPressed));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_GamepadBumperCommandCopyWith<_$_GamepadBumperCommand> get copyWith =>
+      __$$_GamepadBumperCommandCopyWithImpl<_$_GamepadBumperCommand>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_GamepadBumperCommandToJson(this);
+  }
+}
+
+abstract class _GamepadBumperCommand implements GamepadBumperCommand {
+  const factory _GamepadBumperCommand(
+      {required final GamepadBumperType type,
+      required final double isPressed}) = _$_GamepadBumperCommand;
+
+  factory _GamepadBumperCommand.fromJson(Map<String, dynamic> json) =
+      _$_GamepadBumperCommand.fromJson;
+
+  @override
+  GamepadBumperType get type => throw _privateConstructorUsedError;
+  @override
+  double get isPressed => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_GamepadBumperCommandCopyWith<_$_GamepadBumperCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+GamepadDPadCommand _$GamepadDPadCommandFromJson(Map<String, dynamic> json) {
+  return _GamepadDPadCommand.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GamepadDPadCommand {
+  GamepadDPadType get type => throw _privateConstructorUsedError;
+  int get isPressed => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GamepadDPadCommandCopyWith<GamepadDPadCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GamepadDPadCommandCopyWith<$Res> {
+  factory $GamepadDPadCommandCopyWith(
+          GamepadDPadCommand value, $Res Function(GamepadDPadCommand) then) =
+      _$GamepadDPadCommandCopyWithImpl<$Res>;
+  $Res call({GamepadDPadType type, int isPressed});
+}
+
+/// @nodoc
+class _$GamepadDPadCommandCopyWithImpl<$Res>
+    implements $GamepadDPadCommandCopyWith<$Res> {
+  _$GamepadDPadCommandCopyWithImpl(this._value, this._then);
+
+  final GamepadDPadCommand _value;
+  // ignore: unused_field
+  final $Res Function(GamepadDPadCommand) _then;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? isPressed = freezed,
+  }) {
+    return _then(_value.copyWith(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadDPadType,
+      isPressed: isPressed == freezed
+          ? _value.isPressed
+          : isPressed // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_GamepadDPadCommandCopyWith<$Res>
+    implements $GamepadDPadCommandCopyWith<$Res> {
+  factory _$$_GamepadDPadCommandCopyWith(_$_GamepadDPadCommand value,
+          $Res Function(_$_GamepadDPadCommand) then) =
+      __$$_GamepadDPadCommandCopyWithImpl<$Res>;
+  @override
+  $Res call({GamepadDPadType type, int isPressed});
+}
+
+/// @nodoc
+class __$$_GamepadDPadCommandCopyWithImpl<$Res>
+    extends _$GamepadDPadCommandCopyWithImpl<$Res>
+    implements _$$_GamepadDPadCommandCopyWith<$Res> {
+  __$$_GamepadDPadCommandCopyWithImpl(
+      _$_GamepadDPadCommand _value, $Res Function(_$_GamepadDPadCommand) _then)
+      : super(_value, (v) => _then(v as _$_GamepadDPadCommand));
+
+  @override
+  _$_GamepadDPadCommand get _value => super._value as _$_GamepadDPadCommand;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? isPressed = freezed,
+  }) {
+    return _then(_$_GamepadDPadCommand(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadDPadType,
+      isPressed: isPressed == freezed
+          ? _value.isPressed
+          : isPressed // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_GamepadDPadCommand implements _GamepadDPadCommand {
+  const _$_GamepadDPadCommand({required this.type, required this.isPressed});
+
+  factory _$_GamepadDPadCommand.fromJson(Map<String, dynamic> json) =>
+      _$$_GamepadDPadCommandFromJson(json);
+
+  @override
+  final GamepadDPadType type;
+  @override
+  final int isPressed;
+
+  @override
+  String toString() {
+    return 'GamepadDPadCommand(type: $type, isPressed: $isPressed)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_GamepadDPadCommand &&
+            const DeepCollectionEquality().equals(other.type, type) &&
+            const DeepCollectionEquality().equals(other.isPressed, isPressed));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(type),
+      const DeepCollectionEquality().hash(isPressed));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_GamepadDPadCommandCopyWith<_$_GamepadDPadCommand> get copyWith =>
+      __$$_GamepadDPadCommandCopyWithImpl<_$_GamepadDPadCommand>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_GamepadDPadCommandToJson(this);
+  }
+}
+
+abstract class _GamepadDPadCommand implements GamepadDPadCommand {
+  const factory _GamepadDPadCommand(
+      {required final GamepadDPadType type,
+      required final int isPressed}) = _$_GamepadDPadCommand;
+
+  factory _GamepadDPadCommand.fromJson(Map<String, dynamic> json) =
+      _$_GamepadDPadCommand.fromJson;
+
+  @override
+  GamepadDPadType get type => throw _privateConstructorUsedError;
+  @override
+  int get isPressed => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_GamepadDPadCommandCopyWith<_$_GamepadDPadCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+GamepadButtonCommand _$GamepadButtonCommandFromJson(Map<String, dynamic> json) {
+  return _GamepadButtonCommand.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GamepadButtonCommand {
+  GamepadButtonType get type => throw _privateConstructorUsedError;
+  bool get isPressed => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GamepadButtonCommandCopyWith<GamepadButtonCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GamepadButtonCommandCopyWith<$Res> {
+  factory $GamepadButtonCommandCopyWith(GamepadButtonCommand value,
+          $Res Function(GamepadButtonCommand) then) =
+      _$GamepadButtonCommandCopyWithImpl<$Res>;
+  $Res call({GamepadButtonType type, bool isPressed});
+}
+
+/// @nodoc
+class _$GamepadButtonCommandCopyWithImpl<$Res>
+    implements $GamepadButtonCommandCopyWith<$Res> {
+  _$GamepadButtonCommandCopyWithImpl(this._value, this._then);
+
+  final GamepadButtonCommand _value;
+  // ignore: unused_field
+  final $Res Function(GamepadButtonCommand) _then;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? isPressed = freezed,
+  }) {
+    return _then(_value.copyWith(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadButtonType,
+      isPressed: isPressed == freezed
+          ? _value.isPressed
+          : isPressed // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_GamepadButtonCommandCopyWith<$Res>
+    implements $GamepadButtonCommandCopyWith<$Res> {
+  factory _$$_GamepadButtonCommandCopyWith(_$_GamepadButtonCommand value,
+          $Res Function(_$_GamepadButtonCommand) then) =
+      __$$_GamepadButtonCommandCopyWithImpl<$Res>;
+  @override
+  $Res call({GamepadButtonType type, bool isPressed});
+}
+
+/// @nodoc
+class __$$_GamepadButtonCommandCopyWithImpl<$Res>
+    extends _$GamepadButtonCommandCopyWithImpl<$Res>
+    implements _$$_GamepadButtonCommandCopyWith<$Res> {
+  __$$_GamepadButtonCommandCopyWithImpl(_$_GamepadButtonCommand _value,
+      $Res Function(_$_GamepadButtonCommand) _then)
+      : super(_value, (v) => _then(v as _$_GamepadButtonCommand));
+
+  @override
+  _$_GamepadButtonCommand get _value => super._value as _$_GamepadButtonCommand;
+
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? isPressed = freezed,
+  }) {
+    return _then(_$_GamepadButtonCommand(
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as GamepadButtonType,
+      isPressed: isPressed == freezed
+          ? _value.isPressed
+          : isPressed // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_GamepadButtonCommand implements _GamepadButtonCommand {
+  const _$_GamepadButtonCommand({required this.type, required this.isPressed});
+
+  factory _$_GamepadButtonCommand.fromJson(Map<String, dynamic> json) =>
+      _$$_GamepadButtonCommandFromJson(json);
+
+  @override
+  final GamepadButtonType type;
+  @override
+  final bool isPressed;
+
+  @override
+  String toString() {
+    return 'GamepadButtonCommand(type: $type, isPressed: $isPressed)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_GamepadButtonCommand &&
+            const DeepCollectionEquality().equals(other.type, type) &&
+            const DeepCollectionEquality().equals(other.isPressed, isPressed));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(type),
+      const DeepCollectionEquality().hash(isPressed));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_GamepadButtonCommandCopyWith<_$_GamepadButtonCommand> get copyWith =>
+      __$$_GamepadButtonCommandCopyWithImpl<_$_GamepadButtonCommand>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_GamepadButtonCommandToJson(this);
+  }
+}
+
+abstract class _GamepadButtonCommand implements GamepadButtonCommand {
+  const factory _GamepadButtonCommand(
+      {required final GamepadButtonType type,
+      required final bool isPressed}) = _$_GamepadButtonCommand;
+
+  factory _GamepadButtonCommand.fromJson(Map<String, dynamic> json) =
+      _$_GamepadButtonCommand.fromJson;
+
+  @override
+  GamepadButtonType get type => throw _privateConstructorUsedError;
+  @override
+  bool get isPressed => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_GamepadButtonCommandCopyWith<_$_GamepadButtonCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/models/gamepad/gamepad_command_type.g.dart
+++ b/lib/models/gamepad/gamepad_command_type.g.dart
@@ -1,0 +1,112 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'gamepad_command_type.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_GamepadAxisCommand _$$_GamepadAxisCommandFromJson(
+        Map<String, dynamic> json) =>
+    _$_GamepadAxisCommand(
+      type: $enumDecode(_$GamepadAxisTypeEnumMap, json['type']),
+      x: (json['x'] as num).toDouble(),
+      y: (json['y'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$$_GamepadAxisCommandToJson(
+        _$_GamepadAxisCommand instance) =>
+    <String, dynamic>{
+      'type': _$GamepadAxisTypeEnumMap[instance.type],
+      'x': instance.x,
+      'y': instance.y,
+    };
+
+const _$GamepadAxisTypeEnumMap = {
+  GamepadAxisType.left: 'left',
+  GamepadAxisType.right: 'right',
+};
+
+_$_GamepadTriggerCommand _$$_GamepadTriggerCommandFromJson(
+        Map<String, dynamic> json) =>
+    _$_GamepadTriggerCommand(
+      type: $enumDecode(_$GamepadTriggerTypeEnumMap, json['type']),
+      value: (json['value'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$$_GamepadTriggerCommandToJson(
+        _$_GamepadTriggerCommand instance) =>
+    <String, dynamic>{
+      'type': _$GamepadTriggerTypeEnumMap[instance.type],
+      'value': instance.value,
+    };
+
+const _$GamepadTriggerTypeEnumMap = {
+  GamepadTriggerType.left: 'left',
+  GamepadTriggerType.right: 'right',
+};
+
+_$_GamepadBumperCommand _$$_GamepadBumperCommandFromJson(
+        Map<String, dynamic> json) =>
+    _$_GamepadBumperCommand(
+      type: $enumDecode(_$GamepadBumperTypeEnumMap, json['type']),
+      isPressed: (json['isPressed'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$$_GamepadBumperCommandToJson(
+        _$_GamepadBumperCommand instance) =>
+    <String, dynamic>{
+      'type': _$GamepadBumperTypeEnumMap[instance.type],
+      'isPressed': instance.isPressed,
+    };
+
+const _$GamepadBumperTypeEnumMap = {
+  GamepadBumperType.left: 'left',
+  GamepadBumperType.right: 'right',
+};
+
+_$_GamepadDPadCommand _$$_GamepadDPadCommandFromJson(
+        Map<String, dynamic> json) =>
+    _$_GamepadDPadCommand(
+      type: $enumDecode(_$GamepadDPadTypeEnumMap, json['type']),
+      isPressed: json['isPressed'] as int,
+    );
+
+Map<String, dynamic> _$$_GamepadDPadCommandToJson(
+        _$_GamepadDPadCommand instance) =>
+    <String, dynamic>{
+      'type': _$GamepadDPadTypeEnumMap[instance.type],
+      'isPressed': instance.isPressed,
+    };
+
+const _$GamepadDPadTypeEnumMap = {
+  GamepadDPadType.left: 'left',
+  GamepadDPadType.right: 'right',
+  GamepadDPadType.up: 'up',
+  GamepadDPadType.down: 'down',
+};
+
+_$_GamepadButtonCommand _$$_GamepadButtonCommandFromJson(
+        Map<String, dynamic> json) =>
+    _$_GamepadButtonCommand(
+      type: $enumDecode(_$GamepadButtonTypeEnumMap, json['type']),
+      isPressed: json['isPressed'] as bool,
+    );
+
+Map<String, dynamic> _$$_GamepadButtonCommandToJson(
+        _$_GamepadButtonCommand instance) =>
+    <String, dynamic>{
+      'type': _$GamepadButtonTypeEnumMap[instance.type],
+      'isPressed': instance.isPressed,
+    };
+
+const _$GamepadButtonTypeEnumMap = {
+  GamepadButtonType.x: 'x',
+  GamepadButtonType.y: 'y',
+  GamepadButtonType.a: 'a',
+  GamepadButtonType.b: 'b',
+  GamepadButtonType.select: 'select',
+  GamepadButtonType.start: 'start',
+  GamepadButtonType.center3: 'center3',
+  GamepadButtonType.home: 'home',
+};

--- a/lib/models/gamepad/gamepad_event_types.dart
+++ b/lib/models/gamepad/gamepad_event_types.dart
@@ -1,0 +1,15 @@
+class GamepadEventTypes {
+  static String androidType = "androidType";
+
+  static String create = 'CREATE';
+  static String button = 'BUTTON';
+  static String axis = 'AXIS';
+  static String dpad = 'DPAD';
+  static String stickLeft = 'STICK_LEFT';
+  static String stickRight = 'STICK_RIGHT';
+  static String videoOk = 'VIDEO_OK';
+  static String lostLeyFrame = 'LOST_KEYFRAME';
+  static String rcAnalytics = 'RC_ANALYTICS';
+  static String bitrateAnalytics = 'BITRATE_ANALYTICS';
+  static String poorConnection = 'POOR_CONNECTION';
+}

--- a/lib/services/gamepad_controller.dart
+++ b/lib/services/gamepad_controller.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:rxdart/subjects.dart';
+import 'package:test/models/gamepad/gamepad_axis_type.dart';
+import 'package:test/models/gamepad/gamepad_command_type.dart';
+import 'package:test/models/gamepad/gamepad_event_types.dart';
+
+class GamepadController {
+  static const eventChannel = EventChannel('com.example.test/gamepad_channel');
+  late StreamSubscription _eventChannel;
+
+  final StreamController<GamepadCommand> _commandStreamController = StreamController<GamepadCommand>.broadcast();
+  Stream<GamepadCommand> get commandStream => _commandStreamController.stream.asBroadcastStream();
+  Stream<GamepadCommand> get axisStream =>
+      _commandStreamController.stream.asBroadcastStream().where((cmd) => cmd.type == GamepadCommandType.axis);
+
+  // Joysticks
+  // {androidType: AXIS, sourceInput: STICK_RIGHT, x: 1.0, y: 0.0}
+  // {androidType: AXIS, sourceInput: STICK_LEFT, x: 0.15455866, y: 0.0}
+  // released: 0
+
+  // D-pad
+  // left: 1 {androidType: DPAD, direction: 1}
+  // down: 3
+  // right: 2
+  // up: 0
+  // released: -1 {androidType: DPAD, direction: -1}
+
+  // xyab
+  // X: {androidType: BUTTON, keyAction: ACTION_DOWN, keyCode: 99}
+  // x released: {androidType: BUTTON, keyAction: ACTION_UP, keyCode: 99}
+  // x: keyCode 99
+  // y: keyCode 100
+  // a: keyCode 96
+  // b: keyCode 97
+  // bumper left: 102
+  // bumper right: 103
+  // connect/rectangle: 109
+  // menu: 108
+  // open/up center: 130
+  // left stick click: 106
+  // right stick click: 107
+
+  // triggers: {androidType: DPAD, direction: -1} (unusable)
+
+  void setJoystickListener() {
+    _eventChannel = eventChannel.receiveBroadcastStream().listen((event) {
+      final eventParameters = <String, dynamic>{};
+
+      if (event != null && event is String) {
+        event.split(',~').forEach((e) {
+          var createPairList = e.split('=');
+
+          eventParameters[createPairList[0]] = createPairList[1];
+        });
+      }
+
+      if (eventParameters[GamepadEventTypes.androidType] == GamepadEventTypes.button) {
+        print('BUTTON: $eventParameters');
+      } else if (eventParameters[GamepadEventTypes.androidType] == GamepadEventTypes.axis) {
+        print('AXIS: $eventParameters');
+        GamepadCommand command = GamepadCommand(
+            command: GamepadAxisCommand(
+              x: double.parse(eventParameters['x']),
+              y: double.parse(eventParameters['x']),
+              type: getAxisType(eventParameters['sourceInput']),
+            ),
+            type: GamepadCommandType.axis);
+        _commandStreamController.add(command);
+      } else if (eventParameters[GamepadEventTypes.androidType] == GamepadEventTypes.dpad) {
+        print('DPAD: $eventParameters');
+      }
+    });
+  }
+
+  GamepadAxisType getAxisType(String axisString) {
+    switch (axisString.toLowerCase()) {
+      case "stick_right":
+        return GamepadAxisType.right;
+      case "stick_left":
+        return GamepadAxisType.left;
+      default:
+        return GamepadAxisType.right;
+    }
+  }
+
+  void cancel() {
+    _eventChannel.cancel();
+  }
+}

--- a/lib/services/mirv_api.dart
+++ b/lib/services/mirv_api.dart
@@ -14,8 +14,7 @@ class MirvApi {
   String thirdRover = "three";
   String _authToken = "auth token";
 
-  BehaviorSubject<RoverMetrics> periodicMetricUpdates =
-      new BehaviorSubject<RoverMetrics>();
+  BehaviorSubject<RoverMetrics> periodicMetricUpdates = new BehaviorSubject<RoverMetrics>();
 
   String getAuthToken() {
     _authToken = "new auth token";
@@ -23,8 +22,7 @@ class MirvApi {
   }
 
   Future<RoverMetrics> getRoverMetrics(String roverID) async {
-    var response =
-        await http.get(Uri.parse("http://44.202.152.178:8000/rovers/$roverID"));
+    var response = await http.get(Uri.parse("http://mirvapi.azurewebsites.net/rovers/$roverID"));
     String lol =
         '{"roverId":"rover1","state":"docked","status":"available","battery":22,"health":{"electronics":"healthy","drivetrain":"unavailable","intake":"healthy","sensors":"healthy","garage":"degraded","power":"unavailable","general":"degraded"},"telemetry":{"location":{"long":-104.969454,"lat":40.474101},"heading":149.68,"speed":12.62}}';
 
@@ -34,12 +32,8 @@ class MirvApi {
 
   Future<List<RoverSummary>> getRovers() async {
     List<RoverSummary> rovers;
-    var response =
-        await http.get(Uri.parse("http://44.202.152.178:8000/rovers"));
-    rovers = (json.decode(response.body) as List)
-        .map((i) => RoverSummary.fromJson(i))
-        .toList()
-        .obs;
+    var response = await http.get(Uri.parse("http://mirvapi.azurewebsites.net/rovers"));
+    rovers = (json.decode(response.body) as List).map((i) => RoverSummary.fromJson(i)).toList().obs;
     return rovers;
   }
 


### PR DESCRIPTION
Adding dart controller to handle events from a connected gamepad (tested over bluetooth)
- Created GamepadCommand class
- GamepadController features an axisStream, with GamepadAxisCommand events
- Added switch for switching between on-screen joystick and gamepad