### PR TITLE
RoverStateType enums update

### DIFF
--- a/lib/models/gamepad/gamepad_command_type.dart
+++ b/lib/models/gamepad/gamepad_command_type.dart
@@ -53,36 +53,49 @@ class GamepadCommand {
 class GamepadAxisCommand with _$GamepadAxisCommand {
   const factory GamepadAxisCommand(
       {required GamepadAxisType type,
-      required double x, //RoverStateType
+      required double x, //Rover StateType
       required double y}) = __GamepadAxisCommand;
 
-  factory GamepadAxisCommand.fromJson(Map<String, dynamic> json) => _$GamepadAxisCommandFromJson(json);
+  factory GamepadAxisCommand.fromJson(Map<String, dynamic> json) =>
+      _$GamepadAxisCommandFromJson(json);
 }
 
 @freezed
 class GamepadTriggerCommand with _$GamepadTriggerCommand {
-  const factory GamepadTriggerCommand({required GamepadTriggerType type, required double value}) = _GamepadTriggerCommand;
+  const factory GamepadTriggerCommand(
+      {required GamepadTriggerType type,
+      required double value}) = _GamepadTriggerCommand;
 
-  factory GamepadTriggerCommand.fromJson(Map<String, dynamic> json) => _$GamepadTriggerCommandFromJson(json);
+  factory GamepadTriggerCommand.fromJson(Map<String, dynamic> json) =>
+      _$GamepadTriggerCommandFromJson(json);
 }
 
 @freezed
 class GamepadBumperCommand with _$GamepadBumperCommand {
-  const factory GamepadBumperCommand({required GamepadBumperType type, required double isPressed}) = _GamepadBumperCommand;
+  const factory GamepadBumperCommand(
+      {required GamepadBumperType type,
+      required double isPressed}) = _GamepadBumperCommand;
 
-  factory GamepadBumperCommand.fromJson(Map<String, dynamic> json) => _$GamepadBumperCommandFromJson(json);
+  factory GamepadBumperCommand.fromJson(Map<String, dynamic> json) =>
+      _$GamepadBumperCommandFromJson(json);
 }
 
 @freezed
 class GamepadDPadCommand with _$GamepadDPadCommand {
-  const factory GamepadDPadCommand({required GamepadDPadType type, required int isPressed}) = _GamepadDPadCommand;
+  const factory GamepadDPadCommand(
+      {required GamepadDPadType type,
+      required int isPressed}) = _GamepadDPadCommand;
 
-  factory GamepadDPadCommand.fromJson(Map<String, dynamic> json) => _$GamepadDPadCommandFromJson(json);
+  factory GamepadDPadCommand.fromJson(Map<String, dynamic> json) =>
+      _$GamepadDPadCommandFromJson(json);
 }
 
 @freezed
 class GamepadButtonCommand with _$GamepadButtonCommand {
-  const factory GamepadButtonCommand({required GamepadButtonType type, required bool isPressed}) = _GamepadButtonCommand;
+  const factory GamepadButtonCommand(
+      {required GamepadButtonType type,
+      required bool isPressed}) = _GamepadButtonCommand;
 
-  factory GamepadButtonCommand.fromJson(Map<String, dynamic> json) => _$GamepadButtonCommandFromJson(json);
+  factory GamepadButtonCommand.fromJson(Map<String, dynamic> json) =>
+      _$GamepadButtonCommandFromJson(json);
 }

--- a/lib/models/gamepad/gamepad_command_type.freezed.dart
+++ b/lib/models/gamepad/gamepad_command_type.freezed.dart
@@ -21,7 +21,7 @@ GamepadAxisCommand _$GamepadAxisCommandFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$GamepadAxisCommand {
   GamepadAxisType get type => throw _privateConstructorUsedError;
-  double get x => throw _privateConstructorUsedError; //RoverStateType
+  double get x => throw _privateConstructorUsedError; //Rover StateType
   double get y => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -127,7 +127,7 @@ class _$__GamepadAxisCommand implements __GamepadAxisCommand {
   final GamepadAxisType type;
   @override
   final double x;
-//RoverStateType
+//Rover StateType
   @override
   final double y;
 
@@ -179,7 +179,7 @@ abstract class __GamepadAxisCommand implements GamepadAxisCommand {
   GamepadAxisType get type => throw _privateConstructorUsedError;
   @override
   double get x => throw _privateConstructorUsedError;
-  @override //RoverStateType
+  @override //Rover StateType
   double get y => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)

--- a/lib/models/rover_control/rover_command.dart
+++ b/lib/models/rover_control/rover_command.dart
@@ -30,55 +30,76 @@ class RoverCommand with _$RoverCommand {
     @Default(RoverSubsystemType.movement) RoverSubsystemType subsystem,
   }) = MovementRoverCommand;
 
-  factory RoverCommand.fromJson(Map<String, dynamic> json) => _$RoverCommandFromJson(json);
+  factory RoverCommand.fromJson(Map<String, dynamic> json) =>
+      _$RoverCommandFromJson(json);
 }
 
 @freezed
 class RoverCommandParameters with _$RoverCommandParameters {
-  const factory RoverCommandParameters.drivetrain(double x, double y) = RoverCommandParametersDrivetrain;
-  const factory RoverCommandParameters.movement(double lat, double long) = RoverCommandParametersMovement;
+  const factory RoverCommandParameters.drivetrain(double x, double y) =
+      RoverCommandParametersDrivetrain;
+  const factory RoverCommandParameters.movement(double lat, double long) =
+      RoverCommandParametersMovement;
 
-  factory RoverCommandParameters.fromJson(Map<String, dynamic> json) => _$RoverCommandParametersFromJson(json);
+  factory RoverCommandParameters.fromJson(Map<String, dynamic> json) =>
+      _$RoverCommandParametersFromJson(json);
 }
 
 class RoverGeneralCommands {
-  static const eStop = RoverCommand.generalCommand(RoverCommandTypeGeneral.e_stop);
-  static const disable = RoverCommand.generalCommand(RoverCommandTypeGeneral.disable);
-  static const enable = RoverCommand.generalCommand(RoverCommandTypeGeneral.enable);
-  static const deploy = RoverCommand.generalCommand(RoverCommandTypeGeneral.deploy);
+  static const eStop =
+      RoverCommand.generalCommand(RoverCommandTypeGeneral.e_stop);
+  static const disable =
+      RoverCommand.generalCommand(RoverCommandTypeGeneral.disable);
+  static const enable =
+      RoverCommand.generalCommand(RoverCommandTypeGeneral.enable);
+  static const deploy =
+      RoverCommand.generalCommand(RoverCommandTypeGeneral.deploy);
   static const stow = RoverCommand.generalCommand(RoverCommandTypeGeneral.stow);
-  static const startManualControl = RoverCommand.generalCommand(RoverCommandTypeGeneral.start_manual_control);
-  static const stopManualControl = RoverCommand.generalCommand(RoverCommandTypeGeneral.stop_manual_control);
-  static const deployPiLits = RoverCommand.generalCommand(RoverCommandTypeGeneral.deploy_pi_lits);
-  static const retrievePiLits = RoverCommand.generalCommand(RoverCommandTypeGeneral.retrieve_pi_lits);
+  static const startManualControl =
+      RoverCommand.generalCommand(RoverCommandTypeGeneral.start_manual_control);
+  static const stopManualControl =
+      RoverCommand.generalCommand(RoverCommandTypeGeneral.stop_manual_control);
+  static const deployPiLits =
+      RoverCommand.generalCommand(RoverCommandTypeGeneral.deploy_pi_lits);
+  static const retrievePiLits =
+      RoverCommand.generalCommand(RoverCommandTypeGeneral.retrieve_pi_lits);
 }
 
 class RoverIntakeCommands {
-  static const disable = RoverCommand.intakeCommand(RoverCommandTypeIntake.disable);
+  static const disable =
+      RoverCommand.intakeCommand(RoverCommandTypeIntake.disable);
   static const reset = RoverCommand.intakeCommand(RoverCommandTypeIntake.reset);
-  static const intake = RoverCommand.intakeCommand(RoverCommandTypeIntake.intake);
+  static const intake =
+      RoverCommand.intakeCommand(RoverCommandTypeIntake.intake);
   static const store = RoverCommand.intakeCommand(RoverCommandTypeIntake.store);
-  static const deposit = RoverCommand.intakeCommand(RoverCommandTypeIntake.deposit);
-  static const switchLeft = RoverCommand.intakeCommand(RoverCommandTypeIntake.switch_left);
-  static const switchRight = RoverCommand.intakeCommand(RoverCommandTypeIntake.switch_right);
+  static const deposit =
+      RoverCommand.intakeCommand(RoverCommandTypeIntake.deposit);
+  static const switchLeft =
+      RoverCommand.intakeCommand(RoverCommandTypeIntake.switch_left);
+  static const switchRight =
+      RoverCommand.intakeCommand(RoverCommandTypeIntake.switch_right);
 }
 
 class RoverDrivetrainCommands {
-  static DrivetrainRoverCommand drivetrainCommand(RoverCommandTypeDrivetrain command, double x, double y) {
-    return DrivetrainRoverCommand(command, RoverCommandParameters.drivetrain(x, y));
+  static DrivetrainRoverCommand drivetrainCommand(
+      RoverCommandTypeDrivetrain command, double x, double y) {
+    return DrivetrainRoverCommand(
+        command, RoverCommandParameters.drivetrain(x, y));
   }
 }
 
 class RoverMovementCommands {
-  static MovementRoverCommand movementCommand(RoverCommandTypeMovement command, double lat, double long) {
-    return MovementRoverCommand(command, RoverCommandParameters.movement(lat, long));
+  static MovementRoverCommand movementCommand(
+      RoverCommandTypeMovement command, double lat, double long) {
+    return MovementRoverCommand(
+        command, RoverCommandParameters.movement(lat, long));
   }
 }
 
 Map<RoverStateType, List<Pair<RoverCommand, String>>> roverCommandsByState = {
-  RoverStateType.disabled: [],
-  RoverStateType.eStop: [],
-  RoverStateType.remoteOperation: [
+  RoverStateType.disconnected: [],
+  RoverStateType.e_stop: [],
+  RoverStateType.remote_operation: [
     Pair(RoverGeneralCommands.stow, "Stow"),
     Pair(RoverGeneralCommands.deployPiLits, "Deploy Pi Lits"),
     Pair(RoverGeneralCommands.retrievePiLits, "Retrieve Pi Lits"),
@@ -90,8 +111,7 @@ Map<RoverStateType, List<Pair<RoverCommand, String>>> roverCommandsByState = {
     Pair(RoverIntakeCommands.switchLeft, "Switch Left Intake"),
     Pair(RoverIntakeCommands.switchRight, "Switch Right Intake"),
   ],
-  RoverStateType.docked: [
+  RoverStateType.connected_idle_docked: [
     Pair(RoverGeneralCommands.deploy, "Deploy"),
   ],
 };
-

--- a/lib/models/rover_control/rover_command.dart
+++ b/lib/models/rover_control/rover_command.dart
@@ -97,9 +97,31 @@ class RoverMovementCommands {
 }
 
 Map<RoverStateType, List<Pair<RoverCommand, String>>> roverCommandsByState = {
-  RoverStateType.disconnected: [],
+  RoverStateType.disconnected: [
+    // Pair(RoverGeneralCommands.connect, "Connect"), //TODO: maybe add connect command?
+  ],
   RoverStateType.e_stop: [],
+  RoverStateType.disconnected_fault: [],
+  RoverStateType.connected_disabled: [
+    Pair(RoverGeneralCommands.enable, "Enable"),
+  ],
+  RoverStateType.connected_fault: [
+    Pair(RoverGeneralCommands.eStop, "E-Stop"),
+  ],
+  RoverStateType.connected_idle_roaming: [
+    Pair(RoverGeneralCommands.startManualControl, "Manual Control"),
+    Pair(RoverGeneralCommands.disable, "Disable"),
+    //  Pair(RoverGeneralCommands.startAutonomous, "Autonomous"), //TODO: add startAutonomous command
+    Pair(RoverGeneralCommands.eStop, "E-Stop"),
+  ],
+  RoverStateType.autonomous: [
+    Pair(RoverGeneralCommands.stow, "Stow"),
+    Pair(RoverGeneralCommands.eStop, "E-Stop"),
+    Pair(RoverGeneralCommands.disable, "Disable"),
+    //Pair(RoverGeneralCommands.stopAutonomous, "End Autonomous"), //TODO: add stopAutonomous command
+  ],
   RoverStateType.remote_operation: [
+    Pair(RoverGeneralCommands.eStop, "E-Stop"),
     Pair(RoverGeneralCommands.stow, "Stow"),
     Pair(RoverGeneralCommands.deployPiLits, "Deploy Pi Lits"),
     Pair(RoverGeneralCommands.retrievePiLits, "Retrieve Pi Lits"),

--- a/lib/models/rover_metrics.dart
+++ b/lib/models/rover_metrics.dart
@@ -9,14 +9,21 @@ part 'rover_metrics.g.dart';
 @freezed
 class RoverMetrics with _$RoverMetrics {
   const factory RoverMetrics(
-      {@Default("unknown") String roverId,
-      @Default(RoverStateType.remoteOperation) RoverStateType state, //RoverStateType
-      @Default(RoverStatusType.available) RoverStatusType status, //RoverStatusType
-      @Default(-1) int battery,
-      @Default(RoverMetricHealth()) RoverMetricHealth health,
-      @Default(RoverMetricTelemetry()) RoverMetricTelemetry telemetry}) = _RoverMetrics;
+      {@Default("unknown")
+          String roverId,
+      @Default(RoverStateType.disconnected)
+          RoverStateType state, //Rover StateType
+      @Default(RoverStatusType.available)
+          RoverStatusType status, //RoverStatusType
+      @Default(-1)
+          int battery,
+      @Default(RoverMetricHealth())
+          RoverMetricHealth health,
+      @Default(RoverMetricTelemetry())
+          RoverMetricTelemetry telemetry}) = _RoverMetrics;
 
-  factory RoverMetrics.fromJson(Map<String, dynamic> json) => _$RoverMetricsFromJson(json);
+  factory RoverMetrics.fromJson(Map<String, dynamic> json) =>
+      _$RoverMetricsFromJson(json);
 }
 
 @freezed
@@ -31,7 +38,8 @@ class RoverMetricHealth with _$RoverMetricHealth {
     @Default(RoverHealthType.unavailable) RoverHealthType general,
   }) = _RoverMetricHealth;
 
-  factory RoverMetricHealth.fromJson(Map<String, dynamic> json) => _$RoverMetricHealthFromJson(json);
+  factory RoverMetricHealth.fromJson(Map<String, dynamic> json) =>
+      _$RoverMetricHealthFromJson(json);
 }
 
 @freezed
@@ -42,7 +50,8 @@ class RoverMetricTelemetry with _$RoverMetricTelemetry {
     @Default(0.0) double speed,
   }) = _RoverMetricTelemetry;
 
-  factory RoverMetricTelemetry.fromJson(Map<String, dynamic> json) => _$RoverMetricTelemetryFromJson(json);
+  factory RoverMetricTelemetry.fromJson(Map<String, dynamic> json) =>
+      _$RoverMetricTelemetryFromJson(json);
 }
 
 @freezed
@@ -52,5 +61,6 @@ class RoverMetricLocation with _$RoverMetricLocation {
     @Default(0.0) double lat,
   }) = _RoverMetricLocation;
 
-  factory RoverMetricLocation.fromJson(Map<String, dynamic> json) => _$RoverMetricLocationFromJson(json);
+  factory RoverMetricLocation.fromJson(Map<String, dynamic> json) =>
+      _$RoverMetricLocationFromJson(json);
 }

--- a/lib/models/rover_metrics.freezed.dart
+++ b/lib/models/rover_metrics.freezed.dart
@@ -24,7 +24,7 @@ mixin _$RoverMetrics {
   RoverStateType get state =>
       throw _privateConstructorUsedError; //Rover StateType
   RoverStatusType get status =>
-      throw _privateConstructorUsedError; //Rover StatusType
+      throw _privateConstructorUsedError; //RoverStatusType
   int get battery => throw _privateConstructorUsedError;
   RoverMetricHealth get health => throw _privateConstructorUsedError;
   RoverMetricTelemetry get telemetry => throw _privateConstructorUsedError;
@@ -206,7 +206,7 @@ class _$_RoverMetrics implements _RoverMetrics {
   @override
   @JsonKey()
   final RoverStatusType status;
-//Rover StatusType
+//RoverStatusType
   @override
   @JsonKey()
   final int battery;

--- a/lib/models/rover_metrics.freezed.dart
+++ b/lib/models/rover_metrics.freezed.dart
@@ -22,9 +22,9 @@ RoverMetrics _$RoverMetricsFromJson(Map<String, dynamic> json) {
 mixin _$RoverMetrics {
   String get roverId => throw _privateConstructorUsedError;
   RoverStateType get state =>
-      throw _privateConstructorUsedError; //RoverStateType
+      throw _privateConstructorUsedError; //Rover StateType
   RoverStatusType get status =>
-      throw _privateConstructorUsedError; //RoverStatusType
+      throw _privateConstructorUsedError; //Rover StatusType
   int get battery => throw _privateConstructorUsedError;
   RoverMetricHealth get health => throw _privateConstructorUsedError;
   RoverMetricTelemetry get telemetry => throw _privateConstructorUsedError;
@@ -187,7 +187,7 @@ class __$$_RoverMetricsCopyWithImpl<$Res>
 class _$_RoverMetrics implements _RoverMetrics {
   const _$_RoverMetrics(
       {this.roverId = "unknown",
-      this.state = RoverStateType.remoteOperation,
+      this.state = RoverStateType.disconnected,
       this.status = RoverStatusType.available,
       this.battery = -1,
       this.health = const RoverMetricHealth(),
@@ -202,11 +202,11 @@ class _$_RoverMetrics implements _RoverMetrics {
   @override
   @JsonKey()
   final RoverStateType state;
-//RoverStateType
+//Rover StateType
   @override
   @JsonKey()
   final RoverStatusType status;
-//RoverStatusType
+//Rover StatusType
   @override
   @JsonKey()
   final int battery;
@@ -273,7 +273,7 @@ abstract class _RoverMetrics implements RoverMetrics {
   String get roverId => throw _privateConstructorUsedError;
   @override
   RoverStateType get state => throw _privateConstructorUsedError;
-  @override //RoverStateType
+  @override //Rover StateType
   RoverStatusType get status => throw _privateConstructorUsedError;
   @override //RoverStatusType
   int get battery => throw _privateConstructorUsedError;

--- a/lib/models/rover_metrics.g.dart
+++ b/lib/models/rover_metrics.g.dart
@@ -10,7 +10,7 @@ _$_RoverMetrics _$$_RoverMetricsFromJson(Map<String, dynamic> json) =>
     _$_RoverMetrics(
       roverId: json['roverId'] as String? ?? "unknown",
       state: $enumDecodeNullable(_$RoverStateTypeEnumMap, json['state']) ??
-          RoverStateType.remoteOperation,
+          RoverStateType.disconnected,
       status: $enumDecodeNullable(_$RoverStatusTypeEnumMap, json['status']) ??
           RoverStatusType.available,
       battery: json['battery'] as int? ?? -1,
@@ -34,10 +34,15 @@ Map<String, dynamic> _$$_RoverMetricsToJson(_$_RoverMetrics instance) =>
     };
 
 const _$RoverStateTypeEnumMap = {
-  RoverStateType.docked: 'docked',
-  RoverStateType.remoteOperation: 'remoteOperation',
-  RoverStateType.disabled: 'disabled',
-  RoverStateType.eStop: 'eStop',
+  RoverStateType.disconnected: 'disconnected',
+  RoverStateType.disconnected_fault: 'disconnected_fault',
+  RoverStateType.e_stop: 'e_stop',
+  RoverStateType.connected_disabled: 'connected_disabled',
+  RoverStateType.connected_idle_roaming: 'connected_idle_roaming',
+  RoverStateType.connected_idle_docked: 'connected_idle_docked',
+  RoverStateType.connected_fault: 'connected_fault',
+  RoverStateType.autonomous: 'autonomous',
+  RoverStateType.remote_operation: 'remote_operation',
 };
 
 const _$RoverStatusTypeEnumMap = {

--- a/lib/models/rover_state_type.dart
+++ b/lib/models/rover_state_type.dart
@@ -1,1 +1,11 @@
-enum RoverStateType { docked, remoteOperation, disabled, eStop }
+enum RoverStateType {
+  disconnected,
+  disconnected_fault,
+  e_stop,
+  connected_disabled,
+  connected_idle_roaming,
+  connected_idle_docked,
+  connected_fault,
+  autonomous,
+  remote_operation
+}

--- a/lib/models/rover_summary.dart
+++ b/lib/models/rover_summary.dart
@@ -8,10 +8,15 @@ part 'rover_summary.g.dart';
 @freezed
 class RoverSummary with _$RoverSummary {
   const factory RoverSummary(
-      {@Default("unknown") String roverId,
-      @Default(RoverStateType.remoteOperation) RoverStateType state, //RoverStateType
-      @Default(RoverStatusType.available) RoverStatusType status, //RoverStatusType
-      @Default(-1) int battery}) = _RoverSummary;
+      {@Default("unknown")
+          String roverId,
+      @Default(RoverStateType.disconnected)
+          RoverStateType state, //Rover StateType
+      @Default(RoverStatusType.available)
+          RoverStatusType status, //RoverStatusType
+      @Default(-1)
+          int battery}) = _RoverSummary;
 
-  factory RoverSummary.fromJson(Map<String, dynamic> json) => _$RoverSummaryFromJson(json);
+  factory RoverSummary.fromJson(Map<String, dynamic> json) =>
+      _$RoverSummaryFromJson(json);
 }

--- a/lib/models/rover_summary.freezed.dart
+++ b/lib/models/rover_summary.freezed.dart
@@ -22,7 +22,7 @@ RoverSummary _$RoverSummaryFromJson(Map<String, dynamic> json) {
 mixin _$RoverSummary {
   String get roverId => throw _privateConstructorUsedError;
   RoverStateType get state =>
-      throw _privateConstructorUsedError; //RoverStateType
+      throw _privateConstructorUsedError; //Rover StateType
   RoverStatusType get status =>
       throw _privateConstructorUsedError; //RoverStatusType
   int get battery => throw _privateConstructorUsedError;
@@ -139,7 +139,7 @@ class __$$_RoverSummaryCopyWithImpl<$Res>
 class _$_RoverSummary implements _RoverSummary {
   const _$_RoverSummary(
       {this.roverId = "unknown",
-      this.state = RoverStateType.remoteOperation,
+      this.state = RoverStateType.disconnected,
       this.status = RoverStatusType.available,
       this.battery = -1});
 
@@ -152,7 +152,7 @@ class _$_RoverSummary implements _RoverSummary {
   @override
   @JsonKey()
   final RoverStateType state;
-//RoverStateType
+//Rover StateType
   @override
   @JsonKey()
   final RoverStatusType status;
@@ -211,7 +211,7 @@ abstract class _RoverSummary implements RoverSummary {
   String get roverId => throw _privateConstructorUsedError;
   @override
   RoverStateType get state => throw _privateConstructorUsedError;
-  @override //RoverStateType
+  @override //Rover StateType
   RoverStatusType get status => throw _privateConstructorUsedError;
   @override //RoverStatusType
   int get battery => throw _privateConstructorUsedError;

--- a/lib/models/rover_summary.g.dart
+++ b/lib/models/rover_summary.g.dart
@@ -10,7 +10,7 @@ _$_RoverSummary _$$_RoverSummaryFromJson(Map<String, dynamic> json) =>
     _$_RoverSummary(
       roverId: json['roverId'] as String? ?? "unknown",
       state: $enumDecodeNullable(_$RoverStateTypeEnumMap, json['state']) ??
-          RoverStateType.remoteOperation,
+          RoverStateType.disconnected,
       status: $enumDecodeNullable(_$RoverStatusTypeEnumMap, json['status']) ??
           RoverStatusType.available,
       battery: json['battery'] as int? ?? -1,
@@ -25,10 +25,15 @@ Map<String, dynamic> _$$_RoverSummaryToJson(_$_RoverSummary instance) =>
     };
 
 const _$RoverStateTypeEnumMap = {
-  RoverStateType.docked: 'docked',
-  RoverStateType.remoteOperation: 'remoteOperation',
-  RoverStateType.disabled: 'disabled',
-  RoverStateType.eStop: 'eStop',
+  RoverStateType.disconnected: 'disconnected',
+  RoverStateType.disconnected_fault: 'disconnected_fault',
+  RoverStateType.e_stop: 'e_stop',
+  RoverStateType.connected_disabled: 'connected_disabled',
+  RoverStateType.connected_idle_roaming: 'connected_idle_roaming',
+  RoverStateType.connected_idle_docked: 'connected_idle_docked',
+  RoverStateType.connected_fault: 'connected_fault',
+  RoverStateType.autonomous: 'autonomous',
+  RoverStateType.remote_operation: 'remote_operation',
 };
 
 const _$RoverStatusTypeEnumMap = {

--- a/lib/ui/screens/rover_operation_page_widgets/disable_toggle.dart
+++ b/lib/ui/screens/rover_operation_page_widgets/disable_toggle.dart
@@ -1,31 +1,28 @@
 import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:mirv/models/rover_metrics.dart';
 import 'package:mirv/models/rover_control/rover_command.dart';
 import 'package:mirv/models/rover_state_type.dart';
 
-class ToggleDisable extends StatefulWidget {
+class ToggleDisable extends StatelessWidget {
+  late final bool? enabled;
+
   final RoverMetrics? roverMetrics;
   final Function(RoverCommand) sendCommand;
-  const ToggleDisable({
+  ToggleDisable({
     Key? key,
     required this.roverMetrics,
     required this.sendCommand,
-  }) : super(key: key);
+  }) : super(key: key) {
+    enabled = getEnabledState(roverMetrics?.state);
+  }
 
-  @override
-  State<ToggleDisable> createState() => _ToggleDisableState();
-}
-
-class _ToggleDisableState extends State<ToggleDisable> {
-  bool enable = true;
-  _enableState(RoverStateType roverState) {
+  bool? getEnabledState(RoverStateType? roverState) {
     switch (roverState) {
-      case RoverStateType.disconnected:
-
-        ///TODO: implement this so it actually works
-        enable = false;
-        break;
+      case RoverStateType.connected_idle_docked:
+      case RoverStateType.connected_idle_roaming:
+        return true;
+      case RoverStateType.connected_disabled:
+        return false;
       default:
         return null;
     }
@@ -33,20 +30,21 @@ class _ToggleDisableState extends State<ToggleDisable> {
 
   @override
   Widget build(BuildContext context) {
-    // _enableState(widget.roverMetrics != null
-    //     ? widget.roverMetrics!.state
-    //     : RoverStateType.eStop);
     return ElevatedButton(
-        onPressed: () {
-          widget.sendCommand(RoverIntakeCommands.disable);
-          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-            content: Text("Sending signal"),
-          ));
-          setState(() {
-            enable = !enable;
-          });
-        },
-        child: enable == true
+        onPressed: enabled == null
+            ? null
+            : () {
+                switch (enabled) {
+                  case true:
+                    sendCommand(RoverGeneralCommands.disable);
+                    break;
+                  case false:
+                    sendCommand(RoverGeneralCommands.enable);
+                    break;
+                  default:
+                }
+              },
+        child: enabled == true
             ? const Text(
                 'Disable',
                 style: TextStyle(fontSize: 50),

--- a/lib/ui/screens/rover_operation_page_widgets/disable_toggle.dart
+++ b/lib/ui/screens/rover_operation_page_widgets/disable_toggle.dart
@@ -19,10 +19,11 @@ class ToggleDisable extends StatefulWidget {
 
 class _ToggleDisableState extends State<ToggleDisable> {
   bool enable = true;
-
   _enableState(RoverStateType roverState) {
     switch (roverState) {
-      case RoverStateType.disabled:
+      case RoverStateType.disconnected:
+
+        ///TODO: implement this so it actually works
         enable = false;
         break;
       default:

--- a/lib/ui/screens/rover_operation_page_widgets/right_side_buttons.dart
+++ b/lib/ui/screens/rover_operation_page_widgets/right_side_buttons.dart
@@ -52,7 +52,8 @@ class _RightSideButtonsState extends State<RightSideButtons> {
             onPressed: widget.makeCall,
             label: const Text('Connect To Rover'),
             icon: const Icon(Icons.wifi_calling_3),
-            style: ButtonStyle(backgroundColor: MaterialStateProperty.all(Colors.green)),
+            style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.all(Colors.green)),
           ),
         ),
         const SizedBox(
@@ -64,7 +65,8 @@ class _RightSideButtonsState extends State<RightSideButtons> {
           width: 225,
           child: ElevatedButton(
             onPressed: widget.stopCall,
-            style: ButtonStyle(backgroundColor: MaterialStateProperty.all(Colors.green)),
+            style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.all(Colors.green)),
             child: const Text("Stop call"),
           ),
         ),
@@ -76,7 +78,9 @@ class _RightSideButtonsState extends State<RightSideButtons> {
           child: StreamBuilder<RoverMetrics>(
               stream: widget.periodicMetricUpdates,
               builder: (context, snapshot) {
-                return ToggleDisable(roverMetrics: snapshot.data, sendCommand: widget.sendCommand);
+                return ToggleDisable(
+                    roverMetrics: snapshot.data,
+                    sendCommand: widget.sendCommand);
               }),
         ),
         const SizedBox(
@@ -92,11 +96,13 @@ class _RightSideButtonsState extends State<RightSideButtons> {
               }),
         )),
         SizedBox(
-            child: (RoverStateType.remoteOperation == RoverStateType.remoteOperation)
+            child: (RoverStateType.remote_operation ==
+                    RoverStateType.remote_operation)
                 ? Joystick(
                     mode: joystickMode,
                     listener: (details) {
-                      widget.joystickPublish.value = (JoystickValue(details.x, details.y, DateTime.now()));
+                      widget.joystickPublish.value =
+                          (JoystickValue(details.x, details.y, DateTime.now()));
                     },
                   )
                 : null),
@@ -118,10 +124,12 @@ class _RightSideButtonsState extends State<RightSideButtons> {
                 shape: MaterialStateProperty.all<RoundedRectangleBorder>(
                   RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(0),
-                    side: const BorderSide(color: Color.fromARGB(255, 250, 250, 250), width: 10),
+                    side: const BorderSide(
+                        color: Color.fromARGB(255, 250, 250, 250), width: 10),
                   ),
                 ),
-                shadowColor: MaterialStateProperty.all(const Color.fromARGB(0, 0, 0, 0))),
+                shadowColor: MaterialStateProperty.all(
+                    const Color.fromARGB(0, 0, 0, 0))),
           ),
         )
       ],

--- a/lib/ui/screens/rover_operation_page_widgets/rover_status_bar.dart
+++ b/lib/ui/screens/rover_operation_page_widgets/rover_status_bar.dart
@@ -63,19 +63,29 @@ class RoverStatusBar extends StatelessWidget {
     }
   }
 
-  Icon _stateIcon(RoverStateType roverState) {
+  Text _stateText(RoverStateType roverState) {
     switch (roverState) {
       //TODO: implement all new enums so it works well
       case RoverStateType.disconnected:
-        return const Icon(Icons.stop_circle_rounded);
+        return const Text("Disconnected");
+      case RoverStateType.autonomous:
+        return const Text("Autonomous");
+      case RoverStateType.disconnected_fault:
+        return const Text("Disconnected with Error");
+      case RoverStateType.connected_disabled:
+        return const Text("Disabled");
+      case RoverStateType.connected_fault:
+        return const Text("Connected with Error");
+      case RoverStateType.connected_idle_roaming:
+        return const Text("Awaiting Orders");
       case RoverStateType.connected_idle_docked:
-        return const Icon(Icons.inventory);
+        return const Text("Docked");
       case RoverStateType.e_stop:
-        return const Icon(Icons.front_hand); //hexagon?
+        return const Text("E-Stopped"); //hexagon?
       case RoverStateType.remote_operation:
-        return const Icon(Icons.settings_remote_rounded);
+        return const Text("Controlling");
       default:
-        return Icon(Icons.question_mark);
+        return const Text("Idk you kinda screwed up");
     }
   }
 
@@ -113,7 +123,7 @@ class RoverStatusBar extends StatelessWidget {
                 ),
               ),
               _batteryIcon(roverMetrics!.battery),
-              _stateIcon(roverMetrics!.state),
+              _stateText(roverMetrics!.state),
 
               _healthIcon(
                   roverHealthType: roverMetrics!.health.electronics,

--- a/lib/ui/screens/rover_operation_page_widgets/rover_status_bar.dart
+++ b/lib/ui/screens/rover_operation_page_widgets/rover_status_bar.dart
@@ -13,7 +13,8 @@ class RoverStatusBar extends StatelessWidget {
     required this.roverMetrics,
     required this.peerConnectionState,
   }) : super(key: key) {
-    uiConnectionState = Rx<UIConnectionState>(setEnum(peerConnectionState.value));
+    uiConnectionState =
+        Rx<UIConnectionState>(setEnum(peerConnectionState.value));
   }
   final RoverMetrics? roverMetrics;
   final Rx<RTCPeerConnectionState?> peerConnectionState;
@@ -64,18 +65,23 @@ class RoverStatusBar extends StatelessWidget {
 
   Icon _stateIcon(RoverStateType roverState) {
     switch (roverState) {
-      case RoverStateType.disabled:
+      //TODO: implement all new enums so it works well
+      case RoverStateType.disconnected:
         return const Icon(Icons.stop_circle_rounded);
-      case RoverStateType.docked:
+      case RoverStateType.connected_idle_docked:
         return const Icon(Icons.inventory);
-      case RoverStateType.eStop:
+      case RoverStateType.e_stop:
         return const Icon(Icons.front_hand); //hexagon?
-      case RoverStateType.remoteOperation:
+      case RoverStateType.remote_operation:
         return const Icon(Icons.settings_remote_rounded);
+      default:
+        return Icon(Icons.question_mark);
     }
   }
 
-  _healthIcon({required RoverHealthType roverHealthType, required IconData healthIconChoice}) {
+  _healthIcon(
+      {required RoverHealthType roverHealthType,
+      required IconData healthIconChoice}) {
     switch (roverHealthType) {
       case RoverHealthType.degraded:
         return Icon(healthIconChoice, color: Colors.red);
@@ -109,15 +115,29 @@ class RoverStatusBar extends StatelessWidget {
               _batteryIcon(roverMetrics!.battery),
               _stateIcon(roverMetrics!.state),
 
-              _healthIcon(roverHealthType: roverMetrics!.health.electronics, healthIconChoice: Icons.circle), //enconder
-              _healthIcon(roverHealthType: roverMetrics!.health.electronics, healthIconChoice: Icons.handyman), //mechanical
-              _healthIcon(roverHealthType: roverMetrics!.health.general, healthIconChoice: Icons.sensors),
+              _healthIcon(
+                  roverHealthType: roverMetrics!.health.electronics,
+                  healthIconChoice: Icons.circle), //enconder
+              _healthIcon(
+                  roverHealthType: roverMetrics!.health.electronics,
+                  healthIconChoice: Icons.handyman), //mechanical
+              _healthIcon(
+                  roverHealthType: roverMetrics!.health.general,
+                  healthIconChoice: Icons.sensors),
 
               //lidar
-              _healthIcon(roverHealthType: roverMetrics!.health.drivetrain, healthIconChoice: Icons.camera_alt), //camera
-              _healthIcon(roverHealthType: roverMetrics!.health.intake, healthIconChoice: Icons.rotate_90_degrees_ccw), //imu
-              _healthIcon(roverHealthType: roverMetrics!.health.sensors, healthIconChoice: Icons.gps_fixed), //gps
-              _healthIcon(roverHealthType: roverMetrics!.health.garage, healthIconChoice: Icons.garage), //garage
+              _healthIcon(
+                  roverHealthType: roverMetrics!.health.drivetrain,
+                  healthIconChoice: Icons.camera_alt), //camera
+              _healthIcon(
+                  roverHealthType: roverMetrics!.health.intake,
+                  healthIconChoice: Icons.rotate_90_degrees_ccw), //imu
+              _healthIcon(
+                  roverHealthType: roverMetrics!.health.sensors,
+                  healthIconChoice: Icons.gps_fixed), //gps
+              _healthIcon(
+                  roverHealthType: roverMetrics!.health.garage,
+                  healthIconChoice: Icons.garage), //garage
             ]
           : [],
     );


### PR DESCRIPTION
I updated the emuns in RoverStateType to accommodate changes with the rover. the new enums are: 
  (disconnected,
  disconnected_fault,
  e_stop,
  connected_disabled,
  connected_idle_roaming,
  connected_idle_docked,
  connected_fault,
  autonomous,
  remote_operation)
I also went through the code and changed it to accept the new enums